### PR TITLE
PERSONDIR-88 Capture request parameters as user attributes

### DIFF
--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/EchoPersonAttributeDaoImpl.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/EchoPersonAttributeDaoImpl.java
@@ -45,7 +45,8 @@ public class EchoPersonAttributeDaoImpl extends AbstractDefaultAttributePersonAt
             throw new IllegalArgumentException("seed may not be null");
         }
 
-        return Collections.singleton((IPersonAttributes)new AttributeNamedPersonImpl(query));
+        return Collections.singleton((IPersonAttributes)
+                new AttributeNamedPersonImpl(getUsernameAttributeProvider().getUsernameAttribute(), query));
     }
 
     /**

--- a/person-directory-impl/src/main/java/org/jasig/services/persondir/support/jdbc/MultiRowJdbcPersonAttributeDao.java
+++ b/person-directory-impl/src/main/java/org/jasig/services/persondir/support/jdbc/MultiRowJdbcPersonAttributeDao.java
@@ -233,6 +233,7 @@ public class MultiRowJdbcPersonAttributeDao extends AbstractJdbcPersonAttributeD
         for (final Map.Entry<String, Map<String, List<Object>>> mappedAttributesEntry : peopleAttributesBuilder.entrySet()) {
             final String userName = mappedAttributesEntry.getKey();
             final Map<String, List<Object>> attributes = mappedAttributesEntry.getValue();
+            // PERSONDIR-89, PERSONDIR-91 Should this be CaseInsensitiveNamedPersonImpl like SingleRowJdbcPersonAttribute?
             final IPersonAttributes person = new NamedPersonImpl(userName, attributes);
             people.add(person);
         }


### PR DESCRIPTION
https://issues.jasig.org/browse/PERSONDIR-88

Allows capturing request parameters and associating them as user attributes.  The parameters may be direct on the URL or in a redirect parameter (with uPortal, accessing /uPortal?nativeClient=true will go through several redirects and get turned into /uPortal/Login?refUrl=%2FuPortal%2F%3FnativeClient%3Dtrue).  In the preceding example, you can configure RequestAttributeSourceFilter to accept a requestParameter of nativeClient and associate it with whatever attribute names you want.