### PR TITLE
PERSONDIR-90 Do not split User-Agent header into two values on semicolon

### DIFF
--- a/person-directory-impl/src/test/java/org/jasig/services/persondir/support/web/RequestAttributeSourceFilterTest.java
+++ b/person-directory-impl/src/test/java/org/jasig/services/persondir/support/web/RequestAttributeSourceFilterTest.java
@@ -55,6 +55,7 @@ public class RequestAttributeSourceFilterTest extends TestCase {
         requestAttributeSourceFilter.setCookieAttributeMapping(cookieAttributeMapping);
 
         final Map<String, Object>  headerAttributeMapping = new LinkedHashMap<>();
+        headerAttributeMapping.put("User-Agent", "userAgent");
         headerAttributeMapping.put("user.mail", new LinkedHashSet<Object>(Arrays.asList("user.mail", "email")));
         headerAttributeMapping.put("user.name.given", "user.name.given");
         headerAttributeMapping.put("user.name.family", "user.name.family");
@@ -74,10 +75,11 @@ public class RequestAttributeSourceFilterTest extends TestCase {
         EasyMock.expect(servletRequest.getRemoteAddr()).andReturn("127.0.0.1");
         EasyMock.expect(servletRequest.getRemoteHost()).andReturn(null);
         EasyMock.expect(servletRequest.getCookies()).andReturn(new Cookie[] { new Cookie("foo", "bar"), new Cookie("ding", "dong") });
+        EasyMock.expect(servletRequest.getHeader("User-Agent")).andReturn("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/40.0.2214.111 Chrome/40.0.2214.111 Safari/537.36");
         EasyMock.expect(servletRequest.getHeader("user.mail")).andReturn("user1@example.com");
         EasyMock.expect(servletRequest.getHeader("user.name.given")).andReturn("Joe");
         EasyMock.expect(servletRequest.getHeader("user.name.family")).andReturn(null);
-        
+
         filterChain.doFilter(servletRequest, servletResponse);
         EasyMock.expectLastCall();
                 
@@ -99,6 +101,7 @@ public class RequestAttributeSourceFilterTest extends TestCase {
         expectedAttributes.put("ding", Util.list("dong"));
         expectedAttributes.put("ding", Util.list("dong"));
         expectedAttributes.put("email", Util.list("user1@example.com"));
+        expectedAttributes.put("userAgent", Util.list("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/40.0.2214.111 Chrome/40.0.2214.111 Safari/537.36"));
         expectedAttributes.put("user.mail", Util.list("user1@example.com"));
         expectedAttributes.put("user.name.given", Util.list("Joe"));
         expectedAttributes.put("user.name.given", Util.list("Joe"));


### PR DESCRIPTION
https://issues.jasig.org/browse/PERSONDIR-90

Was incorrectly splitting User-Agent on semicolons